### PR TITLE
Implement options.override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ already minified files using `src` setting if you are using a customized name co
 A `function` that takes a file name as input and expected to return minified file name as output. Default
 function adds `.min.` before extension. _(i.e. a.js -> a.min.js)_
 
+### override
+If `true`, then compressed JS will be written into the same files that were compressed. The `target`
+and `deleteSources` options are discarded in this case.
+
+Default: `false`
+
 ### deleteSources
-A boolean, if true original files will be deleted, if false original files will be kept as-is. Default: `false
+A boolean, if true original files will be deleted, if false original files will be kept as-is. Default: `false`
 
 ### uglifyOptions
 A valid config that will be passed to uglifyjs. Please see [here](https://github.com/mishoo/UglifyJS2#compressor-options) for your options. Default:

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ function plugin(options) {
 
       var outName = options.override ? fileName : options.target(fileName);
 
-      if (!_.isObject(files[outName]) && !options.override) {
+      if (!_.isObject(files[outName]) || options.override) {
         let contents = file.contents.toString();
         let baseOpts = {
           fromString: true
@@ -31,7 +31,7 @@ function plugin(options) {
         files[outName] = {contents: new Buffer(result.code)};
       }
 
-      if (options.deleteSources) {
+      if (options.deleteSources && !options.override) {
         delete files[fileName];
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,9 +19,9 @@ function plugin(options) {
         console.log("Uglifiying " + fileName + "...");
       }
 
-      var outName = options.target(fileName);
+      var outName = options.override ? fileName : options.target(fileName);
 
-      if (!_.isObject(files[outName])) {
+      if (!_.isObject(files[outName]) && !options.override) {
         let contents = file.contents.toString();
         let baseOpts = {
           fromString: true

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,7 @@ function normalize(options) {
     src: ["**/*.js", "!**/*.min.js"],
     target: getMinifiedName,
     deleteSources: false,
+    override: false,
     uglifyOptions: {
       mangle: false,
       compress: {}

--- a/test/fixtures/basic/expected6/a.js
+++ b/test/fixtures/basic/expected6/a.js
@@ -1,0 +1,1 @@
+function hello(world){console.log("minify the file!")}

--- a/test/fixtures/basic/expected6/a.min.js
+++ b/test/fixtures/basic/expected6/a.min.js
@@ -1,0 +1,1 @@
+console.log(  "prefinified dont touch"  );

--- a/test/fixtures/basic/expected6/b.js
+++ b/test/fixtures/basic/expected6/b.js
@@ -1,0 +1,1 @@
+function hello(functionB){console.log("this is js b"+functionB)}

--- a/test/index.js
+++ b/test/index.js
@@ -108,4 +108,16 @@ describe("metalsmith-uglifyjs", function() {
         return done();
       });
   });
+
+  it("should override source files, if we set override setting to true", function(done) {
+    Metalsmith("test/fixtures/basic")
+      .use(uglifyjs({
+        override: true
+      }))
+      .build(function(err) {
+        should(err).be.null();
+        assertDirsEqual("test/fixtures/basic/build", "test/fixtures/basic/expected6");
+        return done();
+      });
+  });
 });


### PR DESCRIPTION
Allows you to pass `override: true` to override the source files.

Has some additional changes to https://github.com/ubenzer/metalsmith-uglifyjs/pull/13